### PR TITLE
Electron integration [stopping re-importing for Electron]

### DIFF
--- a/browser-modules.js
+++ b/browser-modules.js
@@ -336,7 +336,7 @@
 
 	var defaultRealm = new Realm(global.require || globalResolve);
 
-	if (typeof module !== 'undefined') {
+	if (typeof module !== 'undefined' && !global.window) {
 		// for node.js
 		module.exports = defaultRealm;
 	} else {


### PR DESCRIPTION
Electron fix:
Since Electron has in build 'require' and 'define' we don't need to re-import them. This fix will make sure that we are not re-importing npm modules if  Electron is being used.
https://github.com/BladeRunnerJS/brjs/issues/1636
